### PR TITLE
Remove RUBY19 constant to avoid warning.

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -4,10 +4,8 @@ require 'ruby_parser'
 require 'optparse'
 
 class File
-  RUBY19 = "<3".respond_to? :encoding
-
   class << self
-    alias :binread :read unless RUBY19
+    alias :binread :read unless "<3".respond_to?(:encoding)
   end
 end
 


### PR DESCRIPTION
When flog and flay are used together Ruby warns for setting the constant twice.
