### PR TITLE
Fixes for #11 and #12

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -487,6 +487,14 @@ class Flog < SexpProcessor
     @total_score
   end
 
+  def max_score
+    max_method[1]
+  end
+
+  def max_method
+    totals.max { |a, b| a[1] <=> b[1] }
+  end
+
   ##
   # Return the total score and populates @totals.
 

--- a/lib/flog_task.rb
+++ b/lib/flog_task.rb
@@ -3,12 +3,16 @@ class FlogTask < Rake::TaskLib
   attr_accessor :dirs
   attr_accessor :threshold
   attr_accessor :verbose
+  attr_accessor :fail_method
+  attr_accessor :parser
 
   def initialize name = :flog, threshold = 200, dirs = nil
     @name      = name
     @dirs      = dirs || %w(app bin lib spec test)
     @threshold = threshold
+    @fail_method = :total
     @verbose   = Rake.application.options.trace
+    @parser    = :RubyParser
 
     yield self if block_given?
 
@@ -22,12 +26,31 @@ class FlogTask < Rake::TaskLib
     task name do
       require "flog"
       flog = Flog.new
+      flog.options[:parser] = case parser
+      when :RubyParser
+        RubyParser
+      when :Ruby18Parser
+        Ruby18Parser
+      when :Ruby19Parser
+        Ruby19Parser
+      else
+        raise "Unknown parser"
+      end
       flog.flog(*dirs)
+       max_method, max_score = flog.max_method #need to grab these values before report resets them.
       flog.report if verbose
 
-      raise "Flog total too high! #{flog.total} > #{threshold}" if
-        flog.total > threshold
+      case fail_method
+      when :total
+        raise "Flog total too high! #{flog.total} > #{threshold}" if
+          flog.total > threshold
+      when :max_method
+        raise "Flog score for method #{max_method} too high! #{max_score} > #{threshold}" if max_score > threshold
+      else
+        raise "Unknow value of fail_method"
+      end
     end
+    
     self
   end
 end

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -672,6 +672,24 @@ class TestFlog < MiniTest::Unit::TestCase
     assert_equal 2.0, @flog.total
   end
 
+  def test_max_method
+    @flog.instance_variable_set :@calls, {
+      "main#none" => {"foo" => 2.0, "bar" => 4.0},
+      "main#meth_one" => {"foo" => 1.0, "bar" => 1.0},
+      "main#meth_two" => {"foo" => 2.0, "bar" => 14.0},
+    }
+    assert_equal ["main#meth_two", 16.0], @flog.max_method
+  end
+
+  def test_max_score
+    @flog.instance_variable_set :@calls, {
+      "main#none" => {"foo" => 2.0, "bar" => 4.0},
+      "main#meth_one" => {"foo" => 1.0, "bar" => 1.0},
+      "main#meth_two" => {"foo" => 2.0, "bar" => 14.0},
+    }
+    assert_equal 16.0, @flog.max_score
+  end
+
   def util_process sexp, score = -1, hash = {}
     setup
     @flog.process sexp


### PR DESCRIPTION
Add the max_score and max_method to Flog.
max_score returns the score of the highest scoring method
max_method returns and an array of [method_name, score] for the highest
scoring method.

Adjusted FlogTask to be able to fail either on total flog score or high
scoring method threshholds.

Made FlogTask actually work (option[:parser] was never getting set)
