### PR TITLE
Ensure rake/tasklib is loaded when defining FlogTask

### DIFF
--- a/lib/flog_task.rb
+++ b/lib/flog_task.rb
@@ -1,3 +1,5 @@
+require 'rake/tasklib'
+
 class FlogTask < Rake::TaskLib
   attr_accessor :name
   attr_accessor :dirs


### PR DESCRIPTION
`rake/tasklib` is no longer (or perhaps never was) loaded by default when loading rake 10.0

`tasklib` is loaded explicitly by some other common tasks that ship with rake, such as `testtask`
