### PR TITLE
Make flog operate on strings

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -255,18 +255,11 @@ class Flog < SexpProcessor
         # TODO: replace File.open to deal with "-"
         ruby = file == '-' ? $stdin.read : File.binread(file)
         warn "** flogging #{file}" if option[:verbose]
-
-        @parser = (option[:parser] || RubyParser).new
-
         begin
-          ast = @parser.process(ruby, file)
+          flog_ruby ruby, file
         rescue Timeout::Error
           warn "TIMEOUT parsing #{file}. Skipping."
         end
-
-        next unless ast
-        mass[file] = ast.mass
-        process ast
       rescue RubyParser::SyntaxError, Racc::ParseError => e
         q = option[:quiet]
         if e.inspect =~ /<\%|%\>/ or ruby =~ /<\%|%\>/ then
@@ -285,6 +278,17 @@ class Flog < SexpProcessor
         end
       end
     end
+  end
+  
+  ##
+  # Flog the given ruby source, optionally using file to provide paths for
+  # methods.
+  
+  def flog_ruby(ruby, file="-")
+    @parser = (option[:parser] || RubyParser).new
+    ast = @parser.process(ruby, file)
+    mass[file] = ast.mass
+    process ast
   end
 
   ##

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -114,6 +114,19 @@ class TestFlog < MiniTest::Unit::TestCase
   ensure
     $stdin = old_stdin
   end
+  
+  def test_flog_ruby
+    ruby = "2 + 3"
+    file = "sample.rb"
+
+    @flog.flog_ruby ruby, file
+
+    exp = { "main#none" => { :+ => 1.0, :lit_fixnum => 0.6 } }
+    assert_equal exp, @flog.calls
+
+    assert_equal 1.6, @flog.total unless @flog.option[:methods]
+    assert_equal 3, @flog.mass[file]
+  end
 
   def test_flog_erb
     old_stdin = $stdin


### PR DESCRIPTION
I broke out the method actually responsible for doing the flogging from the method responsible for reading in the ruby source.  This is a little bit cleaner, and makes it easier to use Flog with arbitrary content.

In my specific case I wanted to call Flog as a library, but couldn't always pass in a file path, and although you could hack around with $stdin, I think this is cleaner.
