### PR TITLE
Problems when parsing an empty file

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -294,6 +294,10 @@ class Flog < SexpProcessor
     warn "** flogging #{file}" if option[:verbose]
 
     ast = @parser.process ruby, file, timeout
+    unless ast then
+      warn "ERROR: processing ruby file #{file}"
+      return
+    end
     mass[file] = ast.mass
     process ast
   end


### PR DESCRIPTION
I originally got an error 

```
/Library/Ruby/Gems/1.8/gems/flog-3.2.1/lib/flog.rb:297:in `flog_ruby!': undefined method `mass' for nil:NilClass (NoMethodError)
    from /Library/Ruby/Gems/1.8/gems/flog-3.2.1/lib/flog.rb:266:in `flog_ruby'
    from /Library/Ruby/Gems/1.8/gems/flog-3.2.1/lib/flog.rb:256:in `flog'
    from /Library/Ruby/Gems/1.8/gems/flog-3.2.1/lib/flog.rb:253:in `each'
    from /Library/Ruby/Gems/1.8/gems/flog-3.2.1/lib/flog.rb:253:in `flog'
    from /Library/Ruby/Gems/1.8/gems/flog-3.2.1/bin/flog:13
    from /usr/bin/flog:19:in `load'
    from /usr/bin/flog:19
```

Which I tracked down to a .rb file in my tree being empty. This pull requests catches that error and possibly other unprocessable files.

It's a bit quick and dirty and may not be the best long term solution though.
