### PR TITLE
Rename Flog#methods methods because it overrides Object#methods (and it contains scores)

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -90,8 +90,7 @@ class Flog < SexpProcessor
   # :stopdoc:
   attr_accessor :multiplier
   attr_reader :calls, :option, :class_stack, :method_stack, :mass, :sclass
-  attr_reader :method_locations
-  attr_reader :methods, :scores
+  attr_reader :method_locations, :method_scores, :scores
 
   # :startdoc:
 
@@ -119,8 +118,8 @@ class Flog < SexpProcessor
     each_by_score threshold do |class_method, score, call_list|
       klass = class_method.split(/#|::/).first
 
-      methods[klass] << [class_method, score]
-      scores[klass]  += score
+      method_scores[klass] << [class_method, score]
+      scores[klass] += score
     end
   end
 
@@ -329,11 +328,11 @@ class Flog < SexpProcessor
   # Reset score data
 
   def reset
-    @totals     = @total_score = nil
-    @multiplier = 1.0
-    @calls      = Hash.new { |h,k| h[k] = Hash.new 0 }
-    @methods    = Hash.new { |h,k| h[k] = [] }
-    @scores     = Hash.new 0
+    @totals           = @total_score = nil
+    @multiplier       = 1.0
+    @calls            = Hash.new { |h,k| h[k] = Hash.new 0 }
+    @method_scores    = Hash.new { |h,k| h[k] = [] }
+    @scores           = Hash.new 0
   end
 
   ##

--- a/lib/flog_cli.rb
+++ b/lib/flog_cli.rb
@@ -8,7 +8,7 @@ class FlogCLI
   extend Forwardable
 
   def_delegators :@flog, :average, :calculate, :each_by_score, :option
-  def_delegators :@flog, :method_locations, :methods, :reset, :scores
+  def_delegators :@flog, :method_locations, :method_scores, :reset, :scores
   def_delegators :@flog, :threshold, :total, :no_method
 
   ##
@@ -133,7 +133,7 @@ class FlogCLI
       next if self.plugins.empty?
       opts.separator "Plugin options:"
 
-      extra = self.methods.grep(/parse_options/) - %w(parse_options)
+      extra = self.method_scores.grep(/parse_options/) - %w(parse_options)
 
       extra.sort.each do |msg|
         self.send msg, opts, option
@@ -199,7 +199,7 @@ class FlogCLI
 
       io.puts "%8.1f: %s" % [total, "#{klass} total"]
 
-      methods[klass].each do |name, score|
+      method_scores[klass].each do |name, score|
         self.print_score io, name, score
       end
     end

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -582,7 +582,7 @@ class TestFlog < FlogTest
     @flog.calculate
 
     assert_equal({ 'MyKlass' => 42.0 }, @flog.scores)
-    assert_equal({ 'MyKlass' => [["MyKlass::Base#mymethod", 42.0]] }, @flog.methods)
+    assert_equal({ 'MyKlass' => [["MyKlass::Base#mymethod", 42.0]] }, @flog.method_scores)
   end
 
   def setup_my_klass


### PR DESCRIPTION
...contains scores)
