### PR TITLE
Fixed grouping by class name

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -124,7 +124,7 @@ class Flog < MethodBasedSexpProcessor
 
   def calculate
     each_by_score threshold do |class_method, score, call_list|
-      klass = class_method.split(/#|::/).first
+      klass = class_method.scan(/.+(?=#|::)/).first
 
       method_scores[klass] << [class_method, score]
       scores[klass] += score

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -540,8 +540,8 @@ class TestFlog < FlogTest
     @flog.calculate_total_scores
     @flog.calculate
 
-    assert_equal({ 'MyKlass' => 42.0 }, @flog.scores)
-    assert_equal({ 'MyKlass' => [["MyKlass::Base#mymethod", 42.0]] }, @flog.method_scores)
+    assert_equal({ 'MyKlass::Base' => 42.0 }, @flog.scores)
+    assert_equal({ 'MyKlass::Base' => [["MyKlass::Base#mymethod", 42.0]] }, @flog.method_scores)
   end
 
   def test_reset
@@ -586,6 +586,35 @@ class TestFlog < FlogTest
     assert_equal(1.0, @flog.multiplier)
     assert_equal({ "Coder#happy?" => { :sample => 1.0 } }, @flog.calls)
     assert_equal({ "Coder" => 1.0 }, @flog.scores)
+  end
+
+  def test_method_scores
+    user_class = %(
+        module User
+          class Account
+            def blah n
+              puts "blah" * n
+            end
+          end
+
+          class Profile
+            def bleh n
+              puts "bleh" * n
+            end
+          end
+        end
+      )
+    user_file = "user.rb"
+
+    @flog.flog_ruby user_class, user_file
+    @flog.calculate_total_scores
+    @flog.calculate
+
+    expected = {
+      "User::Account"=>[["User::Account#blah", 2.2]],
+      "User::Profile"=>[["User::Profile#bleh", 2.2]]
+    }
+    assert_equal(expected, @flog.method_scores)
   end
 
   def setup_my_klass


### PR DESCRIPTION
I was (and am!) using flog while developing a gem of mine but when I use the `group` option, everything is being grouped under the gem name.

That happens because every class is inside a gem_name namespace and splitting on the first `::` will just return the class's first namespace/module.

However, there was already a test for this, so I'm not sure if this behavior was intended.
