### PR TITLE
Update task to add methods_only parameter

### DIFF
--- a/lib/flog_task.rb
+++ b/lib/flog_task.rb
@@ -30,12 +30,13 @@ class FlogTask < Rake::TaskLib
   # Creates a new FlogTask instance with given +name+, +threshold+,
   # +dirs+, and +method+.
 
-  def initialize name = :flog, threshold = 200, dirs = nil, method = nil
-    @name      = name
-    @dirs      = dirs || %w(app bin lib spec test)
-    @threshold = threshold
-    @method    = method || :total_score
-    @verbose   = Rake.application.options.trace
+  def initialize name = :flog, threshold = 200, dirs = nil, method = nil, methods_only = false
+    @name         = name
+    @dirs         = dirs || %w(app bin lib spec test)
+    @threshold    = threshold
+    @method       = method || :total_score
+    @verbose      = Rake.application.options.trace
+    @methods_only = methods_only
 
     yield self if block_given?
 
@@ -51,7 +52,7 @@ class FlogTask < Rake::TaskLib
     desc "Analyze for code complexity in: #{dirs.join(', ')}"
     task name do
       require "flog_cli"
-      flog = FlogCLI.new :continue => true, :quiet => true
+      flog = FlogCLI.new :continue => true, :quiet => true, :methods => @methods_only
       flog.flog(*dirs)
 
       desc, score = flog.send method


### PR DESCRIPTION
I want to use flog in my build with the rake task and set a max score per method, but it's currently failing because main#none has a ridiculously high score. 

I found that I can use the flag -m on the command line but it wasn't available from the rake task. I've just added a parameter defaulted to false, seemed the simplest thing but let me know if you have a better suggestion.
