### PR TITLE
Add support for safe navigation operator `&.`

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -399,6 +399,7 @@ class Flog < MethodBasedSexpProcessor
 
     s()
   end
+  alias :process_safe_call :process_call
 
   def process_case(exp)
     add_to_score :branch

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -190,6 +190,11 @@ class TestFlog < FlogTest
     assert_process sexp, 1.0, :a => 1.0
   end
 
+  def test_process_safe_call
+    sexp = s(:safe_call, nil, :a)
+    assert_process sexp, 1.0, :a => 1.0
+  end
+
   def test_process_case
     case :a
     when :a


### PR DESCRIPTION
In the following code, flog currently does not report any value for the `do_something_safe` method (like it doesn't even exist) and the `total` method call in the `do_branch_safe` method is not scored.
```ruby
def do_something_safe(arg)
  arg&.split
end

def do_something_unsafe(arg)
  arg.split
end

def do_branch_safe(arg)
  if arg&.total
    puts "total"
  end
end

def do_branch_unsafe(arg)
  if arg.total
    puts "total"
  end
end
```
output before:

```$ bin/flog -a -d example.rb 
     5.3: flog total
     1.8: flog/method average

     2.5: main#do_branch_unsafe            example.rb:15-17
     1.2:   puts
     1.1:   branch
     1.1:   total

     1.6: main#do_branch_safe              example.rb:9-11
     1.2:   puts
     1.1:   branch

     1.1: main#do_something_unsafe         example.rb:5-6
     1.1:   split
```

output after:

```
     7.3: flog total
     1.8: flog/method average

     2.5: main#do_branch_safe              ./example.rb:9-11
     1.2:   puts
     1.1:   branch
     1.1:   total

     2.5: main#do_branch_unsafe            ./example.rb:15-17
     1.2:   puts
     1.1:   branch
     1.1:   total

     1.1: main#do_something_safe           ./example.rb:1-2
     1.1:   split

     1.1: main#do_something_unsafe         ./example.rb:5-6
     1.1:   split
```

Right now, just aliased the `process_call` method for `process_safe_call` so they are treated identically. I'm not sure if you'd like to have a different score for the safe calls. Also, contrary to all the other `alias`ed methods, which just have a **TODO** comment for them in the test file, I've just duplicated the `process_call` test over, to make it easier if you decide you want the score tweaked. If you'd like I can remove that and just add it to the **TODO** comment with the rest of the aliases.