### PR TITLE
Fix Flog#flog and FlogCLI::run to use path expansion the same way.

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,15 @@
+=== 4.7.0 / 2019-04-23
+
+* 7 minor enhancements:
+
+ * Modified Flog#flog to expand directories in its arguments into files
+ * Modified FlogCLI::run to use Flog#flog to expand directories into files
+ * Modified test_flog.rb to test expansion of dirs to files.
+ * Modified usage message of FlogCli to show standard input case.
+ * flog_cli.rb uses require_relative such that tests don't used an installed gem file.
+ * bin/flog uses require_relative such that tests don't used an installed gem file.
+ * Modified bin/flog to use /usr/bin/env to select the ruby interpreter.
+
 === 4.6.2 / 2018-02-14
 
 * 1 bug fix:

--- a/bin/flog
+++ b/bin/flog
@@ -1,6 +1,6 @@
-#!/usr/local/bin/ruby -w
+#!/usr/bin/env ruby -w
 
-require "flog_cli"
+require_relative File.join("..", "lib", "flog_cli")
 
 FlogCLI.run
 


### PR DESCRIPTION
Other tools using Flog#flog() can benefit from path expansion that only worked in FlogCLI::run.  The changes I made have them both use the same system for path expansion.  Previously, one could not differentiate whether an abort occurred for:
    * no input files
    * no readable input file

An update to the usage message of flog was made to indicate a dash may be used as an argument to indicate stdin is to be read for ruby code.

A unit test was created to test the new functionality.

Also, small changes were made to make sure developer's running unit tests would not inadvertently get this packages installed ruby gem code during 'requires'.