### PR TITLE
Verify we can use an empty hash as an argument

### DIFF
--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -351,6 +351,19 @@ class TestFlog < FlogTest
     assert_process sexp, 2.3, :something => 1.0, :task => 1.0, :lit_fixnum => 0.3
   end
 
+  def test_process_iter_dsl_hash_when_hash_empty
+    # task({}) do
+    #   something
+    # end
+
+    sexp = s(:iter,
+             s(:call, nil, :task, s(:hash)),
+             nil,
+             s(:call, nil, :something))
+
+    assert_process sexp, 2.326, :something => 1.1, :task => 1.0, :branch => 1
+  end
+
   def test_process_iter_dsl_namespaced
     # namespace :blah do
     #   task :woot => 42 do


### PR DESCRIPTION
Fixes issues discussed in https://github.com/seattlerb/flog/issues/67

I'm running into an issue when running `flog` `4.6.2` in a Rails application containing the following code:

```ruby
respond_with({}, status: :ok, location: false) do |format|
  format.html { redirect_to some_path, notice: "some notice" }
end
```

`flog` fails with the following error

```
/Users/mattvh/.gem/ruby/2.5.5/gems/flog-4.6.2/lib/flog.rb:151:in `dsl_name?': undefined method `[]' for nil:NilClass (NoMethodError)
```

After some investigation, I have ascertained that the `dsl_name` method assumes that when a hash is passed as the first argument to a method, it will never be an empty hash literal, and it attempts to index various parts out of the resulting `sexp` to determine what structure the hash has.

I have fixed this in this commit: https://github.com/eightbitraptor/flog/commit/c97dd0cbe73d218f382e8f455e5ea14afde0adcb

This commit adds a regression test to confirm that master doesn't exhibit the broken behaviour