### PR TITLE
Handle complex literals

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -515,7 +515,7 @@ class Flog < MethodBasedSexpProcessor
       # first/last
     when Integer, Rational then
       add_to_score :lit_fixnum
-    when Float, Symbol, Regexp, Range then
+    when Float, Symbol, Regexp, Range, Complex then
       # do nothing
     else
       raise "Unhandled lit: #{value.inspect}:#{value.class}"

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -437,6 +437,11 @@ class TestFlog < FlogTest
     assert_process sexp, 0.0
   end
 
+  def test_process_lit_complex
+    sexp = s(:lit, (0+1i))
+    assert_process sexp, 0.0
+  end
+
   def test_process_lit_bad
     assert_raises RuntimeError do
       @flog.process s(:lit, Object.new)


### PR DESCRIPTION
I was trying to run RubyCritic on a large codebase with complex numbers showing up in _exactly_ one place, which crashed the run entirely.  Perhaps RubyCritic should absorb the error, but it does seem like an omission in Flog, so (ta-da) here's a PR for it.