### PR TITLE
Add missing ruby_parser dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ Hoe.spec 'flog' do
   license "MIT"
 
   dependency "sexp_processor", "~> 4.8"
+  dependency "ruby_parser",    "~> 3.1"
   dependency "prism",          "~> 1.5"
   dependency "path_expander",  "~> 2.0"
 


### PR DESCRIPTION
## Problem
Issue: https://github.com/seattlerb/flog/issues/83
Flog v4.9.0 fails with error: "Unable to load ruby_parser"

## Root Cause
Version 4.9.0 switched to `prism` gem, but `prism/translation/ruby_parser` 
still requires the actual `ruby_parser` gem which was removed from dependencies.

## Solution
Add `ruby_parser` back as a runtime dependency.

## Testing
Verified in production Rails app that this resolves the issue.