### PR TITLE
Fix default parser assignment after options.dup

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -233,8 +233,8 @@ class Flog < MethodBasedSexpProcessor
     @option              = option.dup
     @mass                = {}
     @parser              = nil
-    @threshold           = option[:threshold] || DEFAULT_THRESHOLD
-    option[:parser]    ||= NotRubyParser
+    @threshold           = @option[:threshold] || DEFAULT_THRESHOLD
+    @option[:parser]   ||= NotRubyParser
     self.auto_shift_type = true
     self.reset
   end

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -697,3 +697,15 @@ class TestFlog < FlogTest
     @flog.add_to_score "blah", 42
   end
 end
+
+class TestFlogDefaultOptions < Minitest::Test
+  def test_flog_with_default_options
+    # Regression test for issue #84
+    # Flog should work with default options (no explicit parser)
+    flog = Flog.new
+    flog.flog_ruby "2 + 3", "test.rb"
+    flog.calculate_total_scores
+
+    assert_in_epsilon 1.6, flog.total_score
+  end
+end


### PR DESCRIPTION
After commit 108e801, the options hash is duplicated to prevent FrozenError. However, the default parser assignment still used the local parameter instead of the instance variable, causing 'undefined method new for nil' errors.

Fixes #84