### PR TITLE
Score safe navigation in block-pass position

### DIFF
--- a/lib/flog.rb
+++ b/lib/flog.rb
@@ -375,7 +375,7 @@ class Flog < MethodBasedSexpProcessor
       # do nothing
     when :lit then                                                     # f(&:b)
       # do nothing -- this now costs about the same as a block
-    when :call then                                                    # f(&x.b)
+    when :call, :safe_call then                                        # f(&x.b) / f(&x&.b)
       # do nothing -- I don't like the indirection, but that's already scored
     when :lasgn then                                                   # f(&l=b)
       add_to_score :to_proc_lasgn

--- a/test/test_flog.rb
+++ b/test/test_flog.rb
@@ -138,6 +138,18 @@ class TestFlog < FlogTest
                    :b              => 1.2)
   end
 
+  def test_process_block_pass__safe_call
+    sexp = s(:call, nil, :a,
+             s(:block_pass,
+               s(:safe_call, s(:call, nil, :b), :c)))             # a(&b&.c)
+
+    assert_process(sexp, 4.9,
+                   :a              => 1.0,
+                   :block_pass     => 1.2,
+                   :b              => 1.5,
+                   :c              => 1.2)
+  end
+
   def test_process_block_pass__to_proc
     sexp = s(:call, nil, :a,
              s(:block_pass, s(:lit, :to_i)))


### PR DESCRIPTION

## What

`foo(&obj&.meth)` crashes Flog. This teaches the block-pass handler about safe navigation, so it scores the same as a plain call. Fixes #87.

## Why

`Flog#process_block_pass` switches on the block-pass argument's node type. It handles a plain call (`:call`) but not safe navigation (`:safe_call`), so `f(&x&.b)` falls to the `else` and raises `block_pass_even_ickier!`. Safe navigation already scores in normal position through `process_safe_call`. Only this handler missed it. Same shape as #73 (`&{hash}`), fixed the same way.

## Change

One line in `lib/flog.rb`:

```diff
-    when :call then                                                    # f(&x.b)
+    when :call, :safe_call then                                        # f(&x.b) / f(&x&.b)
```

## Test

Added `test_process_block_pass__safe_call`, modeled on the existing `__call` test. It errors without the fix and passes with it. `a(&b&.c)` scores 4.9.

- Before: 60 runs, 0 failures
- After: 61 runs, 0 failures
